### PR TITLE
Align peer dependencies with the ones defined in dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
   },
   "homepage": "https://github.com/emilgoldsmith/stylelint-custom-processor-loader#readme",
   "peerDependencies": {
-    "stylelint": "7.13.0",
-    "webpack": "3.2.0"
+    "stylelint": "^8.0.0",
+    "webpack": "^3.2.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
It seems that peer dependencies were not updated together with the respective dev dependencies.

This change prevents ``Incorrect peer dependency "stylelint@7.13.0"`` and ``Incorrect peer dependency "webpack@3.2.0"`` warnings from showing up during ``yarn`` or ``npm install``.