### PR TITLE
Allow stylelint warnings to be displayed in Webpack

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -3,6 +3,7 @@
   "extends": "stylelint-config-standard",
   "syntax": "scss",
   "rules": {
-    "color-named": "never"
+    "color-named": "never",
+    "block-no-empty": [true, { "severity": "warning" }]
   }
 }

--- a/index.js
+++ b/index.js
@@ -48,6 +48,8 @@ module.exports = function(content) {
       const { output } = resultObject;
       if (resultObject.errored) {
         this.emitError(new StylelintError(output));
+      } else if (output) {
+        this.emitWarning(new StylelintError(output));
       }
       callback(null, content);
     })

--- a/test/configs/styled-components.json
+++ b/test/configs/styled-components.json
@@ -3,6 +3,7 @@
   "extends": "stylelint-config-standard",
   "syntax": "scss",
   "rules": {
-    "color-named": "never"
+    "color-named": "never",
+    "block-no-empty": [true, { "severity": "warning" }]
   }
 }

--- a/test/fixtures/styled-components/warnings.js
+++ b/test/fixtures/styled-components/warnings.js
@@ -1,0 +1,5 @@
+import styled from 'styled-components';
+
+const Button1 = styled.button`
+  a { }
+`;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -36,7 +36,7 @@ export const prepWebpack = (entry, options) => {
 export const deleteWebpackOutput = () =>
   fs.unlinkSync('./test/webpack-test.out.js');
 
-export const assertNoErrors = stats => {
+export const assertNoErrorsOrWarnings = stats => {
   expect(stats.hasErrors()).toBe(false);
   expect(stats.hasWarnings()).toBe(false);
 };
@@ -52,6 +52,16 @@ export const assertSpecificErrors = (...args) => stats => {
   args.forEach((regex, index) => {
     expect(regex.test(errors[index])).toBe(true);
     expect(stats.hasWarnings()).toBe(false);
+  });
+};
+
+export const assertSpecificWarnings = (...args) => stats => {
+  expect(stats.hasWarnings()).toBe(true);
+  const warnings = stats.toJson().warnings;
+  expect(warnings.length).toBe(args.length);
+  args.forEach((regex, index) => {
+    expect(regex.test(warnings[index])).toBe(true);
+    expect(stats.hasErrors()).toBe(false);
   });
 };
 

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1,8 +1,9 @@
 import {
   prepWebpack,
   deleteWebpackOutput,
+  assertNoErrorsOrWarnings,
   assertSpecificErrors,
-  assertNoErrors,
+  assertSpecificWarnings,
   handleCatch,
 } from './helpers';
 
@@ -25,10 +26,27 @@ describe('stylelint-custom-processor', () => {
       .catch(handleCatch);
   });
 
+  it('finds warnings', done => {
+    const webpackInstance = prepWebpack(
+      './test/fixtures/styled-components/warnings.js'
+    );
+
+    const expectedWarningsRegex = /block-no-empty[\s\S]*/;
+    webpackInstance
+      .run()
+      .then(assertSpecificWarnings(expectedWarningsRegex))
+      .then(done)
+      .catch(handleCatch);
+  });
+
   it('handles correct file', done => {
     const webpackInstance = prepWebpack(
       './test/fixtures/styled-components/valid.js'
     );
-    webpackInstance.run().then(assertNoErrors).then(done).catch(handleCatch);
+    webpackInstance
+      .run()
+      .then(assertNoErrorsOrWarnings)
+      .then(done)
+      .catch(handleCatch);
   });
 });


### PR DESCRIPTION
This PR adds the ability to view warnings in Webpack.

Previously, only errors were showing up in Webpack; so, if the `defaultSeverity` was set to `warning`, no output would show up. Displaying warnings allows linting messages to be viewed in Webpack without sending an error code that halts the build process. 