### PR TITLE
Add option to only emit warnings (#51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ module: {
 }
 ```
 
+### emitWarning (default: `false`)
+
+Always return warnings if this option is set to `true`. If you're using hot module replacement, you may wish to enable this in development, or else updates will be skipped when there's an stylelint error.
+
 ## License
 
 Licensed under the MIT License, Copyright © 2017 Emil Goldsmith Olesen. See [LICENSE](./LICENSE) for more information.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ module: {
 
 ### emitWarning (default: `false`)
 
-Always return warnings if this option is set to `true`. If you're using hot module replacement, you may wish to enable this in development, or else updates will be skipped when there's an stylelint error.
+Always return warnings if this option is set to `true`. If you're using hot module replacement, you may wish to enable this in development, or else updates will be skipped when there's a stylelint error.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -36,6 +36,10 @@ module.exports = function(content) {
     codeFilename: this.resourcePath,
     formatter: 'string',
   };
+
+  // shortcut for emitWarning option
+  const emitWarning = options && options.emitWarning;
+
   if (options && options.configPath) {
     let processedPath = loaderUtils.stringifyRequest(this, options.configPath);
     processedPath = processedPath.substring(1, processedPath.length - 1);
@@ -46,7 +50,7 @@ module.exports = function(content) {
     .lint(lintArgument)
     .then(resultObject => {
       const { output } = resultObject;
-      if (resultObject.errored) {
+      if (resultObject.errored && !emitWarning) {
         this.emitError(new StylelintError(output));
       } else if (output) {
         this.emitWarning(new StylelintError(output));

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -3,6 +3,7 @@ import {
   deleteWebpackOutput,
   assertNoErrors,
   assertSpecificErrors,
+  assertSpecificWarnings,
 } from './helpers';
 
 if (process.env.CIRCLECI) {
@@ -27,6 +28,19 @@ describe('options', () => {
       }
     );
     return webpackInstance.run().then(assertNoErrors);
+  });
+
+  it('handles emitWarning option', () => {
+    const webpackInstance = prepWebpack(
+      `${__dirname}/fixtures/styled-components/invalid.js`,
+      {
+        emitWarning: true,
+      }
+    );
+    const expectedWarningsRegex = /color-named[\s\S]*?max-empty-lines[\s\S]*?declaration-empty-line-before/;
+    return webpackInstance
+      .run()
+      .then(assertSpecificWarnings(expectedWarningsRegex));
   });
 
   it('chooses correct config', () => {


### PR DESCRIPTION
Fixes #51 
Spec resembles eslint: https://github.com/webpack-contrib/eslint-loader#errors-and-warning